### PR TITLE
increase minSdk to 21

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -19,7 +19,7 @@ android {
     compileSdkVersion 33
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 33
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'proguard-rules.pro'

--- a/lib/src/main/jni/Application.mk
+++ b/lib/src/main/jni/Application.mk
@@ -1,7 +1,7 @@
 APP_STL := c++_shared
 APP_OPTIM := release
 APP_ABI := armeabi-v7a,arm64-v8a,x86,x86_64
-APP_PLATFORM := android-16
+APP_PLATFORM := android-21
 NDK_TOOLCHAIN_VERSION := clang
 NDK_APP_LIBS_OUT=../jniLibs
 # Temp workaround for https://github.com/android-ndk/ndk/issues/332


### PR DESCRIPTION
[spatia-room](https://github.com/anboralabs/spatia-room) already uses minSdk 21, so we can also increase it for android-spatialite.

One benefit of this is that the resulting native library (libandroid_spatialite.so) will have more functions protected by the [fortify flag](https://android-developers.googleblog.com/2017/04/fortify-in-android.html), something that some 3rd-party Android app stores require during their security scan. 

This can be checked with the [checksec](https://manpages.ubuntu.com/manpages/focal/en/man1/checksec.1.html) tool - with the current minSdk 16, it reports that the 32-bit variants of the library were not using the fortify flag.