### PR TITLE
use NDK 27, support flexible page sizes

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,3 @@
 before_install:
   - sdk install java 17.0.11-jbr
   - sdk use java 17.0.11-jbr
-  - yes | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-34"
-  - yes | $ANDROID_HOME/tools/bin/sdkmanager "build-tools;34.0.0"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -8,20 +8,22 @@ plugins {
 
 group = 'com.github.dalgarins'
 
-gradle.projectsEvaluated {
-    preBuild.dependsOn(buildSqlite)
-}
-
 android {
     namespace 'org.spatialite'
     compileSdk 34
-    ndkVersion '21.0.6113669'
+    ndkVersion '27.3.13750724'
 
     defaultConfig {
         minSdk 21
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+
+        externalNativeBuild {
+            ndkBuild {
+                arguments "-j8", "V=1"
+            }
+        }
     }
 
     buildTypes {
@@ -42,6 +44,12 @@ android {
     }
 
     sourceSets.main.jni.srcDirs = ['src/main/none']
+
+    externalNativeBuild {
+        ndkBuild {
+            path "src/main/jni/Android.mk"
+        }
+    }
 }
 
 ext {
@@ -62,46 +70,7 @@ tasks.register('installSqlite', Copy) {
     into 'src/main/jni/ndk-modules/sqlite'
 }
 
-def ndkDir = System.getenv("NDK_HOME")
-if (ndkDir == null) {
-    def propertiesFile = project.rootProject.file('local.properties')
-    if (propertiesFile.exists()) {
-        Properties properties = new Properties()
-        properties.load(propertiesFile.newDataInputStream())
-        ndkDir = properties.getProperty('ndk.dir')
-        if (ndkDir == null) {
-            throw GradleScriptException("Either NDK_HOME or ndk.dir in local.properties should point to Android NDK!")
-        }
-    } else {
-        throw GradleScriptException("Either NDK_HOME or ndk.dir in local.properties should point to Android NDK!")
-    }
-}
-
-tasks.register('buildSqlite', Exec) {
-    dependsOn installSqlite
-    println("NDK directory: $ndkDir")
-
-    // Add NDK_DEBUG=1 for debug symbols or V=1 for verbose building output
-    if (OperatingSystem.current().linux) {
-        commandLine "$ndkDir/ndk-build", '-j8', '-C', file('src/main/jni').absolutePath
-    } else if (OperatingSystem.current().windows) {
-        commandLine "$ndkDir/ndk-build.cmd", '-j8', '-C', file('src/main/jni').absolutePath
-    } else {
-        commandLine "$ndkDir/ndk-build", '-j8', '-C', file('src/main/jni').absolutePath
-    }
-}
-
-tasks.register('ndkClean', Exec) {
-    if (OperatingSystem.current().linux) {
-        commandLine "$ndkDir/ndk-build", 'clean', '-C', file('src/main/jni').absolutePath
-    } else if (OperatingSystem.current().windows) {
-        commandLine "$ndkDir/ndk-build.cmd", 'clean', '-C', file('src/main/jni').absolutePath
-    } else {
-        commandLine "$ndkDir/ndk-build", 'clean', '-C', file('src/main/jni').absolutePath
-    }
-}
-
-clean.dependsOn 'ndkClean'
+preBuild.dependsOn installSqlite
 
 dependencies {
 

--- a/lib/src/main/jni/Android.mk
+++ b/lib/src/main/jni/Android.mk
@@ -34,7 +34,7 @@ include $(BUILD_SHARED_LIBRARY)
 # The library concrete version subfolder name must match its .mk file.
 # E.g. libxml2-2.9.2/ -> libxml2-2.9.2.mk
 
-NDK_MODULES_PATH := ndk-modules
+NDK_MODULES_PATH := $(LOCAL_PATH)/ndk-modules
 
 SPATIALITE_PATH := libspatialite-4.3.0a
 PROJ4_PATH := proj-4.8.0

--- a/lib/src/main/jni/Application.mk
+++ b/lib/src/main/jni/Application.mk
@@ -2,6 +2,8 @@ APP_STL := c++_shared
 APP_OPTIM := release
 APP_ABI := armeabi-v7a,arm64-v8a,x86,x86_64
 APP_PLATFORM := android-21
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
+APP_CPPFLAGS := -std=c++14
 NDK_TOOLCHAIN_VERSION := clang
 NDK_APP_LIBS_OUT=../jniLibs
 # Temp workaround for https://github.com/android-ndk/ndk/issues/332

--- a/lib/src/main/jni/ndk-modules/libiconv/libiconv-1.13.mk
+++ b/lib/src/main/jni/ndk-modules/libiconv/libiconv-1.13.mk
@@ -6,7 +6,7 @@ LOCAL_MODULE := iconv
 LOCAL_CFLAGS    := \
     -Wno-multichar \
     -D_ANDROID \
-    -DLIBDIR "$(LOCAL_PATH)/$(ICONV_PATH)/libcharset/lib" \
+    -DLIBDIR=\"$(LOCAL_PATH)/$(ICONV_PATH)/libcharset/lib\" \
     -DBUILDING_LIBICONV \
     -DIN_LIBRARY
 


### PR DESCRIPTION
As mentioned in https://github.com/anboralabs/spatia-room/issues/56, since Android 15, new devices may use a 16KB page size instead of the previous default 4KB. Native libraries have to be built with this in mind. See also [Gooogle's documentation](https://developer.android.google.cn/guide/practices/page-sizes?hl=en).

This PR upgrades the build to use NDK 27 and enables `APP_SUPPORT_FLEXIBLE_PAGE_SIZES` to support 16KB page size. Also, I simplified the Gradle configuration by using `externalNativeBuild` to invoke `ndk-build` instead of the additional custom tasks. This also has the benefit that Gradle will automatically download the specified NDK version and this doesn't have to be configured in `jitpack.yml` anymore.

There is one problem unfortunately: The **build on Jitpack now fails**. I think the reason is that it takes slightly longer than their 15 minute limit and therefore gets killed. So you would likely need to set up publishing to Maven Central instead.